### PR TITLE
Fix warning in publishDockerImages.yml workflow

### DIFF
--- a/.github/workflows/publishDockerImages.yml
+++ b/.github/workflows/publishDockerImages.yml
@@ -54,7 +54,10 @@ jobs:
 
       - name: Set vars.branch
         id: vars
-        run: BRANCH=${GITHUB_REF#refs/*/} && echo ${BRANCH} && echo "::set-output name=branch::${BRANCH}"
+        run: |
+          BRANCH=${GITHUB_REF#refs/*/}
+          echo ${BRANCH}
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Extract metadata (tags, labels) for docker image
         id: meta


### PR DESCRIPTION
Use the "$GITHUB_OUTPUT" variable instead of the deprecated "::set-output" expression to write command output.