### PR TITLE
fix panic when req.ControlMessage is nil

### DIFF
--- a/bridge/service/service.go
+++ b/bridge/service/service.go
@@ -119,7 +119,7 @@ func (c *Service) DefaultRequestHandler(req *net.Request) (*pool.Message, error)
 	}
 	d, err := c.LoadDevice(deviceID) // check if device exists et
 	if err != nil {
-		if req.ControlMessage().Dst.IsMulticast() {
+		if req.ControlMessage() != nil && req.ControlMessage().Dst.IsMulticast() {
 			return nil, nil //nolint:nilnil
 		}
 		return nil, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by adding a nil check for the ControlMessage to prevent potential runtime errors.
	- Enhanced the robustness of the request handling process, minimizing the risk of issues related to nil dereferencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->