### PR TITLE
Fix decoding failure from large doxm.sct value and improve error messages

### DIFF
--- a/pkg/codec/ocf/codec.go
+++ b/pkg/codec/ocf/codec.go
@@ -64,7 +64,7 @@ func (VNDOCFCBORCodec) Decode(m *pool.Message, v interface{}) error {
 	}
 	if err := cbor.ReadFrom(m.Body(), v); err != nil {
 		p, _ := m.Options().Path()
-		return fmt.Errorf("decoding failed for the message %v on %v", m.Token(), p)
+		return fmt.Errorf("decoding failed for the message %v on %v with error: %w", m.Token(), p, err)
 	}
 	return nil
 }

--- a/schema/credential/credential.go
+++ b/schema/credential/credential.go
@@ -86,7 +86,7 @@ func (c CredentialType) String() string {
 		c &^= CredentialType_ASYMMETRIC_ENCRYPTION_KEY
 	}
 	if c != 0 {
-		res = append(res, fmt.Sprintf("unknown(%v)", uint8(c)))
+		res = append(res, fmt.Sprintf("unknown(%v)", uint16(c)))
 	}
 	return strings.Join(res, "|")
 }

--- a/schema/credential/credential.go
+++ b/schema/credential/credential.go
@@ -44,7 +44,7 @@ type Credential struct {
 	Tag                     string                    `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
-type CredentialType uint8
+type CredentialType uint16
 
 const (
 	CredentialType_EMPTY                               CredentialType = 0


### PR DESCRIPTION
The default value of doxm.sct set by iotivity-lite can be larger than uint8 which leads to a failed decoding of Doxm resource.
I have found out that this default doxm config set by IoTivity-Lite https://github.com/iotivity/iotivity-lite/blob/master/security/oc_doxm.c#L231 could result in the sct=457. As the sct is in the scheme uint8 the decoding fails.

I have also extended the error message as it can save a lot of time in future by providing what exactly went wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the decoding process, providing more context on failures for better debugging.

- **New Features**
	- Expanded the range of values for `CredentialType` by changing its data type from `uint8` to `uint16`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->