### PR TITLE
Extend signers to set CRL Distribution Points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ unit-test: certificates
 		go test -race -parallel 1 -v ./bridge/... -coverpkg=./... -covermode=atomic -coverprofile=$(TMP_PATH)/bridge.unit.coverage.txt
 	go test -race -v ./schema/... -covermode=atomic -coverprofile=$(TMP_PATH)/schema.unit.coverage.txt
 	ROOT_CA_CRT="$(ROOT_CA_CRT)" ROOT_CA_KEY="$(ROOT_CA_KEY)" \
+	INTERMEDIATE_CA_CRT="$(INTERMEDIATE_CA_CRT)" INTERMEDIATE_CA_KEY=$(INTERMEDIATE_CA_KEY) \
 		go test -race -v ./pkg/... -covermode=atomic -coverprofile=$(TMP_PATH)/pkg.unit.coverage.txt
 
 test: env build-testcontainer

--- a/cmd/bridge-device/Dockerfile
+++ b/cmd/bridge-device/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR $GOPATH/src/github.com/plgd-dev/device
 RUN CGO_ENABLED=0 go build -o /go/bin/bridge-device ./cmd/bridge-device
 
 FROM alpine:3.20 AS security-provider
-RUN apk add -U --no-cache ca-certificates
-RUN addgroup -S nonroot \
+RUN apk add -U --no-cache ca-certificates \
+    && addgroup -S nonroot \
     && adduser -S nonroot -G nonroot
 
 FROM scratch AS service

--- a/cmd/ocfclient/main.go
+++ b/cmd/ocfclient/main.go
@@ -523,8 +523,8 @@ func NewSecureClient() (*local.Client, error) {
 				ID:      CertIdentity,
 				Cert:    string(IdentityIntermediateCA),
 				CertKey: string(IdentityIntermediateCAKey),
-				CreateSignerFunc: func(caCert []*x509.Certificate, caKey crypto.PrivateKey, validNotBefore time.Time, validNotAfter time.Time) core.CertificateSigner {
-					return signer.NewOCFIdentityCertificate(caCert, caKey, validNotBefore, validNotAfter)
+				CreateSignerFunc: func(caCert []*x509.Certificate, caKey crypto.PrivateKey, validNotBefore, validNotAfter time.Time, crlDistributionPoints []string) (core.CertificateSigner, error) {
+					return signer.NewOCFIdentityCertificate(caCert, caKey, validNotBefore, validNotAfter, crlDistributionPoints)
 				},
 			},
 		}

--- a/pkg/security/generateCertificate/config_test.go
+++ b/pkg/security/generateCertificate/config_test.go
@@ -112,3 +112,60 @@ func TestToIPAddresses(t *testing.T) {
 	expected := []net.IP{net.ParseIP("192.168.0.1"), net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")}
 	require.Equal(t, expected, ips)
 }
+
+func TestToCRLDistributionPoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     generateCertificate.Configuration
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "Valid CRL URLs",
+			cfg: generateCertificate.Configuration{
+				CRLDistributionPoints: []string{
+					"http://example.com/crl1",
+					"http://example.com/crl2",
+				},
+			},
+			want: []string{"http://example.com/crl1", "http://example.com/crl2"},
+		},
+		{
+			name: "Duplicate CRL URLs",
+			cfg: generateCertificate.Configuration{
+				CRLDistributionPoints: []string{
+					"http://example.com/crl1",
+					"http://example.com/crl1", // duplicate
+				},
+			},
+			want: []string{"http://example.com/crl1"},
+		},
+		{
+			name: "Invalid CRL URL",
+			cfg: generateCertificate.Configuration{
+				CRLDistributionPoints: []string{
+					"invalid-url",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Empty CRL list",
+			cfg: generateCertificate.Configuration{
+				CRLDistributionPoints: []string{},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crls, err := tt.cfg.ToCRLDistributionPoints()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.ElementsMatch(t, tt.want, crls)
+		})
+	}
+}

--- a/pkg/security/generateCertificate/generateCertificate_test.go
+++ b/pkg/security/generateCertificate/generateCertificate_test.go
@@ -1,15 +1,227 @@
-package generateCertificate
+package generateCertificate_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenerateCSR(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	validCfg := func() generateCertificate.Configuration {
+		cfg := generateCertificate.Configuration{}
+		cfg.Subject.Country = []string{"US"}
+		cfg.Subject.Organization = []string{"TestOrg"}
+		cfg.Subject.CommonName = "test.example.com"
+		cfg.SubjectAlternativeName.DNSNames = []string{"example.com"}
+		cfg.BasicConstraints.Ignore = true
+		cfg.BasicConstraints.MaxPathLen = -1
+		cfg.ValidFor = time.Hour * 24
+		return cfg
+	}()
+
+	type args struct {
+		cfg generateCertificate.Configuration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		verify  func(t *testing.T, cfg generateCertificate.Configuration, parsedCSR *x509.CertificateRequest)
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				cfg: validCfg,
+			},
+			verify: func(t *testing.T, cfg generateCertificate.Configuration, parsedCSR *x509.CertificateRequest) {
+				require.Equal(t, cfg.Subject.CommonName, parsedCSR.Subject.CommonName)
+				require.ElementsMatch(t, cfg.Subject.Country, parsedCSR.Subject.Country)
+				require.ElementsMatch(t, cfg.Subject.Organization, parsedCSR.Subject.Organization)
+				require.ElementsMatch(t, cfg.SubjectAlternativeName.DNSNames, parsedCSR.DNSNames)
+			},
+		},
+		{
+			name: "valid with basic constraint",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.BasicConstraints.Ignore = false
+					cfg.BasicConstraints.MaxPathLen = 42
+					return cfg
+				}(),
+			},
+			verify: func(t *testing.T, cfg generateCertificate.Configuration, parsedCSR *x509.CertificateRequest) {
+				require.Equal(t, cfg.Subject.CommonName, parsedCSR.Subject.CommonName)
+				require.ElementsMatch(t, cfg.Subject.Country, parsedCSR.Subject.Country)
+				require.ElementsMatch(t, cfg.Subject.Organization, parsedCSR.Subject.Organization)
+				require.ElementsMatch(t, cfg.SubjectAlternativeName.DNSNames, parsedCSR.DNSNames)
+				var bcExt *pkix.Extension
+				for _, ext := range parsedCSR.Extensions {
+					if slices.Equal(ext.Id, generateCertificate.ASN1BasicConstraints) {
+						bcExt = &ext
+					}
+				}
+				require.NotNil(t, bcExt)
+				require.False(t, bcExt.Critical)
+				var bc generateCertificate.BasicConstraints
+				_, err := asn1.Unmarshal(bcExt.Value, &bc)
+				require.NoError(t, err)
+				require.False(t, bc.CA)
+			},
+		},
+		{
+			name: "valid with key usages",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.KeyUsages = append(cfg.KeyUsages, "digitalSignature", "certSign")
+					return cfg
+				}(),
+			},
+			verify: func(t *testing.T, cfg generateCertificate.Configuration, parsedCSR *x509.CertificateRequest) {
+				require.Equal(t, cfg.Subject.CommonName, parsedCSR.Subject.CommonName)
+				require.ElementsMatch(t, cfg.Subject.Country, parsedCSR.Subject.Country)
+				require.ElementsMatch(t, cfg.Subject.Organization, parsedCSR.Subject.Organization)
+				require.ElementsMatch(t, cfg.SubjectAlternativeName.DNSNames, parsedCSR.DNSNames)
+				var kuExt *pkix.Extension
+				for _, ext := range parsedCSR.Extensions {
+					if slices.Equal(ext.Id, generateCertificate.ASN1KeyUsage) {
+						kuExt = &ext
+					}
+				}
+				require.NotNil(t, kuExt)
+				require.False(t, kuExt.Critical)
+				var ku asn1.BitString
+				_, err := asn1.Unmarshal(kuExt.Value, &ku)
+				require.NoError(t, err)
+				keyUsages, err := cfg.AsnKeyUsages()
+				require.NoError(t, err)
+				require.Equal(t, keyUsages, ku)
+			},
+		},
+		{
+			name: "valid with extended key usages",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.ExtensionKeyUsages = append(cfg.ExtensionKeyUsages,
+						asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 3}.String(),
+						asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 9}.String())
+					return cfg
+				}(),
+			},
+			verify: func(t *testing.T, cfg generateCertificate.Configuration, parsedCSR *x509.CertificateRequest) {
+				require.Equal(t, cfg.Subject.CommonName, parsedCSR.Subject.CommonName)
+				require.ElementsMatch(t, cfg.Subject.Country, parsedCSR.Subject.Country)
+				require.ElementsMatch(t, cfg.Subject.Organization, parsedCSR.Subject.Organization)
+				require.ElementsMatch(t, cfg.SubjectAlternativeName.DNSNames, parsedCSR.DNSNames)
+				var ekuExt *pkix.Extension
+				for _, ext := range parsedCSR.Extensions {
+					if slices.Equal(ext.Id, generateCertificate.ASN1ExtKeyUsage) {
+						ekuExt = &ext
+					}
+				}
+				require.NotNil(t, ekuExt)
+				require.False(t, ekuExt.Critical)
+				var ekus []asn1.ObjectIdentifier
+				_, err := asn1.Unmarshal(ekuExt.Value, &ekus)
+				require.NoError(t, err)
+				x509ExtKeyUsages, unknownKeyUsages, err := cfg.X509ExtKeyUsages()
+				require.NoError(t, err)
+				var extKeyUsages []asn1.ObjectIdentifier
+				for _, e := range x509ExtKeyUsages {
+					eku, ok := generateCertificate.OidFromExtKeyUsage(e)
+					require.True(t, ok)
+					extKeyUsages = append(extKeyUsages, eku)
+				}
+				extKeyUsages = append(extKeyUsages, unknownKeyUsages...)
+				require.ElementsMatch(t, extKeyUsages, ekus)
+			},
+		},
+		{
+			name: "invalid IP address",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.SubjectAlternativeName.IPAddresses = []string{"invalid-ip"}
+					return cfg
+				}(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid signature algorithm",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.SignatureAlgorithm = "invalid-algorithm"
+					return cfg
+				}(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid key usages",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.KeyUsages = []string{"invalid-usage"}
+					return cfg
+				}(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid extended key usages",
+			args: args{
+				cfg: func() generateCertificate.Configuration {
+					cfg := validCfg
+					cfg.ExtensionKeyUsages = []string{"invalid-eku"}
+					return cfg
+				}(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			csr, err := generateCertificate.GenerateCSR(tt.args.cfg, privateKey)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, csr)
+
+			// Parse the PEM-encoded CSR and verify it's well-formed
+			block, _ := pem.Decode(csr)
+			require.NotNil(t, block)
+			require.Equal(t, "CERTIFICATE REQUEST", block.Type)
+
+			parsedCSR, err := x509.ParseCertificateRequest(block.Bytes)
+			require.NoError(t, err)
+			tt.verify(t, tt.args.cfg, parsedCSR)
+		})
+	}
+}
+
 func TestGenerateCertificate(t *testing.T) {
 	type args struct {
-		cfg Configuration
+		cfg generateCertificate.Configuration
 	}
 	tests := []struct {
 		name    string
@@ -19,7 +231,7 @@ func TestGenerateCertificate(t *testing.T) {
 		{
 			name: "valid - default",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor: time.Minute,
 				},
 			},
@@ -27,36 +239,36 @@ func TestGenerateCertificate(t *testing.T) {
 		{
 			name: "valid - sha384",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:           time.Minute,
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA384,
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA384,
 				},
 			},
 		},
 		{
 			name: "valid - sha512",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:           time.Minute,
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA512,
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA512,
 				},
 			},
 		},
 		{
 			name: "valid - p384",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:      time.Minute,
-					EllipticCurve: EllipticCurveP384,
+					EllipticCurve: generateCertificate.EllipticCurveP384,
 				},
 			},
 		},
 		{
 			name: "valid - p521",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:      time.Minute,
-					EllipticCurve: EllipticCurveP521,
+					EllipticCurve: generateCertificate.EllipticCurveP521,
 				},
 			},
 		},
@@ -66,7 +278,7 @@ func TestGenerateCertificate(t *testing.T) {
 			caCrt, caKey := generateRootCA(t, tt.args.cfg)
 			privateKey, err := tt.args.cfg.GenerateKey()
 			require.NoError(t, err)
-			got, err := GenerateCert(tt.args.cfg, privateKey, caCrt, caKey)
+			got, err := generateCertificate.GenerateCert(tt.args.cfg, privateKey, caCrt, caKey)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/security/generateCertificate/generateIdentityCertificate_test.go
+++ b/pkg/security/generateCertificate/generateIdentityCertificate_test.go
@@ -1,15 +1,16 @@
-package generateCertificate
+package generateCertificate_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateIdentityCertificate(t *testing.T) {
 	type args struct {
-		cfg Configuration
+		cfg generateCertificate.Configuration
 	}
 	tests := []struct {
 		name    string
@@ -19,7 +20,7 @@ func TestGenerateIdentityCertificate(t *testing.T) {
 		{
 			name: "valid - default",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor: time.Minute,
 				},
 			},
@@ -27,36 +28,36 @@ func TestGenerateIdentityCertificate(t *testing.T) {
 		{
 			name: "valid - sha384",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:           time.Minute,
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA384,
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA384,
 				},
 			},
 		},
 		{
 			name: "valid - sha512",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:           time.Minute,
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA512,
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA512,
 				},
 			},
 		},
 		{
 			name: "valid - p384",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:      time.Minute,
-					EllipticCurve: EllipticCurveP384,
+					EllipticCurve: generateCertificate.EllipticCurveP384,
 				},
 			},
 		},
 		{
 			name: "valid - p521",
 			args: args{
-				cfg: Configuration{
+				cfg: generateCertificate.Configuration{
 					ValidFor:      time.Minute,
-					EllipticCurve: EllipticCurveP521,
+					EllipticCurve: generateCertificate.EllipticCurveP521,
 				},
 			},
 		},
@@ -66,7 +67,7 @@ func TestGenerateIdentityCertificate(t *testing.T) {
 			caCrt, caKey := generateRootCA(t, tt.args.cfg)
 			privateKey, err := tt.args.cfg.GenerateKey()
 			require.NoError(t, err)
-			got, err := GenerateIdentityCert(tt.args.cfg, "deviceID", privateKey, caCrt, caKey)
+			got, err := generateCertificate.GenerateIdentityCert(tt.args.cfg, "deviceID", privateKey, caCrt, caKey)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/security/generateCertificate/generateIntermediateCA_test.go
+++ b/pkg/security/generateCertificate/generateIntermediateCA_test.go
@@ -1,18 +1,19 @@
-package generateCertificate
+package generateCertificate_test
 
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"testing"
 
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
 	pkgX509 "github.com/plgd-dev/device/v2/pkg/security/x509"
 	"github.com/stretchr/testify/require"
 )
 
-func generateRootCA(t *testing.T, cfg Configuration) ([]*x509.Certificate, *ecdsa.PrivateKey) {
+func generateRootCA(t *testing.T, cfg generateCertificate.Configuration) ([]*x509.Certificate, *ecdsa.PrivateKey) {
 	privateKey, err := cfg.GenerateKey()
 	require.NoError(t, err)
-	cert, err := GenerateRootCA(cfg, privateKey)
+	cert, err := generateCertificate.GenerateRootCA(cfg, privateKey)
 	require.NoError(t, err)
 	crt, err := pkgX509.ParsePemCertificates(cert)
 	require.NoError(t, err)
@@ -21,7 +22,7 @@ func generateRootCA(t *testing.T, cfg Configuration) ([]*x509.Certificate, *ecds
 
 func TestGenerateIntermediateCA(t *testing.T) {
 	type args struct {
-		cfg Configuration
+		cfg generateCertificate.Configuration
 	}
 	tests := []struct {
 		name    string
@@ -31,38 +32,38 @@ func TestGenerateIntermediateCA(t *testing.T) {
 		{
 			name: "valid - default",
 			args: args{
-				cfg: Configuration{},
+				cfg: generateCertificate.Configuration{},
 			},
 		},
 		{
 			name: "valid - sha384",
 			args: args{
-				cfg: Configuration{
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA384,
+				cfg: generateCertificate.Configuration{
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA384,
 				},
 			},
 		},
 		{
 			name: "valid - sha512",
 			args: args{
-				cfg: Configuration{
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA512,
+				cfg: generateCertificate.Configuration{
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA512,
 				},
 			},
 		},
 		{
 			name: "valid - p384",
 			args: args{
-				cfg: Configuration{
-					EllipticCurve: EllipticCurveP384,
+				cfg: generateCertificate.Configuration{
+					EllipticCurve: generateCertificate.EllipticCurveP384,
 				},
 			},
 		},
 		{
 			name: "valid - p521",
 			args: args{
-				cfg: Configuration{
-					EllipticCurve: EllipticCurveP521,
+				cfg: generateCertificate.Configuration{
+					EllipticCurve: generateCertificate.EllipticCurveP521,
 				},
 			},
 		},
@@ -72,7 +73,7 @@ func TestGenerateIntermediateCA(t *testing.T) {
 			caCrt, caKey := generateRootCA(t, tt.args.cfg)
 			privateKey, err := tt.args.cfg.GenerateKey()
 			require.NoError(t, err)
-			got, err := GenerateIntermediateCA(tt.args.cfg, privateKey, caCrt, caKey)
+			got, err := generateCertificate.GenerateIntermediateCA(tt.args.cfg, privateKey, caCrt, caKey)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/security/generateCertificate/generateRootCA.go
+++ b/pkg/security/generateCertificate/generateRootCA.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GenerateRootCA(cfg Configuration, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	cacert, err := newCert(cfg)
+	cacert, err := newCert(cfg, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/generateCertificate/generateRootCA_test.go
+++ b/pkg/security/generateCertificate/generateRootCA_test.go
@@ -1,14 +1,15 @@
-package generateCertificate
+package generateCertificate_test
 
 import (
 	"testing"
 
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRootCA(t *testing.T) {
 	type args struct {
-		cfg Configuration
+		cfg generateCertificate.Configuration
 	}
 	tests := []struct {
 		name    string
@@ -18,38 +19,38 @@ func TestGenerateRootCA(t *testing.T) {
 		{
 			name: "valid - default",
 			args: args{
-				cfg: Configuration{},
+				cfg: generateCertificate.Configuration{},
 			},
 		},
 		{
 			name: "valid - sha384",
 			args: args{
-				cfg: Configuration{
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA384,
+				cfg: generateCertificate.Configuration{
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA384,
 				},
 			},
 		},
 		{
 			name: "valid - sha512",
 			args: args{
-				cfg: Configuration{
-					SignatureAlgorithm: SignatureAlgorithmECDSAWithSHA512,
+				cfg: generateCertificate.Configuration{
+					SignatureAlgorithm: generateCertificate.SignatureAlgorithmECDSAWithSHA512,
 				},
 			},
 		},
 		{
 			name: "valid - p384",
 			args: args{
-				cfg: Configuration{
-					EllipticCurve: EllipticCurveP384,
+				cfg: generateCertificate.Configuration{
+					EllipticCurve: generateCertificate.EllipticCurveP384,
 				},
 			},
 		},
 		{
 			name: "valid - p521",
 			args: args{
-				cfg: Configuration{
-					EllipticCurve: EllipticCurveP521,
+				cfg: generateCertificate.Configuration{
+					EllipticCurve: generateCertificate.EllipticCurveP521,
 				},
 			},
 		},
@@ -58,7 +59,7 @@ func TestGenerateRootCA(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			privateKey, err := tt.args.cfg.GenerateKey()
 			require.NoError(t, err)
-			got, err := GenerateRootCA(tt.args.cfg, privateKey)
+			got, err := generateCertificate.GenerateRootCA(tt.args.cfg, privateKey)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/security/signer/basicCertificateSigner.go
+++ b/pkg/security/signer/basicCertificateSigner.go
@@ -1,0 +1,72 @@
+package signer
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"errors"
+	"math/big"
+	"time"
+
+	pkgX509 "github.com/plgd-dev/device/v2/pkg/security/x509"
+)
+
+type BasicCertificateSigner struct {
+	caCert                []*x509.Certificate
+	caKey                 crypto.PrivateKey
+	validNotBefore        time.Time
+	validNotAfter         time.Time
+	crlDistributionPoints []string
+}
+
+func NewBasicCertificateSigner(caCert []*x509.Certificate, caKey crypto.PrivateKey, validNotBefore, validNotAfter time.Time, crlDistributionPoints []string) (*BasicCertificateSigner, error) {
+	if err := pkgX509.ValidateCRLDistributionPoints(crlDistributionPoints); err != nil {
+		return nil, err
+	}
+	return &BasicCertificateSigner{
+		caCert:                caCert,
+		caKey:                 caKey,
+		validNotBefore:        validNotBefore,
+		validNotAfter:         validNotAfter,
+		crlDistributionPoints: crlDistributionPoints,
+	}, nil
+}
+
+func (s *BasicCertificateSigner) Sign(_ context.Context, csr []byte) ([]byte, error) {
+	certificateRequest, err := pkgX509.ParseAndCheckCertificateRequest(csr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(s.caCert) == 0 {
+		return nil, errors.New("cannot sign with empty signer CA certificates")
+	}
+	notBefore := s.validNotBefore
+	notAfter := s.validNotAfter
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+	template := x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		Subject:               certificateRequest.Subject,
+		PublicKeyAlgorithm:    certificateRequest.PublicKeyAlgorithm,
+		PublicKey:             certificateRequest.PublicKey,
+		SignatureAlgorithm:    s.caCert[0].SignatureAlgorithm,
+		DNSNames:              certificateRequest.DNSNames,
+		IPAddresses:           certificateRequest.IPAddresses,
+		URIs:                  certificateRequest.URIs,
+		EmailAddresses:        certificateRequest.EmailAddresses,
+		ExtraExtensions:       certificateRequest.Extensions,
+		CRLDistributionPoints: s.crlDistributionPoints,
+	}
+	signedCsr, err := x509.CreateCertificate(rand.Reader, &template, s.caCert[0], certificateRequest.PublicKey, s.caKey)
+	if err != nil {
+		return nil, err
+	}
+	return pkgX509.CreatePemChain(s.caCert, signedCsr)
+}

--- a/pkg/security/signer/basicCertificateSigner_test.go
+++ b/pkg/security/signer/basicCertificateSigner_test.go
@@ -1,0 +1,201 @@
+package signer_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/device/v2/pkg/net/coap"
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
+	"github.com/plgd-dev/device/v2/pkg/security/signer"
+	pkgX509 "github.com/plgd-dev/device/v2/pkg/security/x509"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBasicCertificateSigner(t *testing.T) {
+	caCert, err := pkgX509.ReadPemCertificates(os.Getenv("INTERMEDIATE_CA_CRT"))
+	require.NoError(t, err)
+	caKey, err := pkgX509.ReadPemEcdsaPrivateKey(os.Getenv("INTERMEDIATE_CA_KEY"))
+	require.NoError(t, err)
+	type args struct {
+		caCert         []*x509.Certificate
+		caKey          crypto.PrivateKey
+		validNotBefore time.Time
+		validNotAfter  time.Time
+		crlPoints      []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*x509.Certificate
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				caCert:         caCert,
+				caKey:          caKey,
+				validNotBefore: time.Now(),
+				validNotAfter:  time.Now().Add(time.Hour * 86400),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid CRL address",
+			args: args{
+				caCert:         caCert,
+				caKey:          caKey,
+				validNotBefore: time.Now().Add(-time.Second),
+				validNotAfter:  time.Now().Add(time.Hour),
+				crlPoints:      []string{"invalid-crl-address"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := signer.NewBasicCertificateSigner(tt.args.caCert, tt.args.caKey, tt.args.validNotBefore, tt.args.validNotAfter, tt.args.crlPoints)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBasicCertificateSignerSign(t *testing.T) {
+	caCert, err := pkgX509.ReadPemCertificates(os.Getenv("INTERMEDIATE_CA_CRT"))
+	require.NoError(t, err)
+	caKey, err := pkgX509.ReadPemEcdsaPrivateKey(os.Getenv("INTERMEDIATE_CA_KEY"))
+	require.NoError(t, err)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	csrCfg := generateCertificate.Configuration{}
+	csrCfg.Subject.CommonName = "uuid:00000000-0000-0000-0000-000000000001"
+	csrCfg.ExtensionKeyUsages = []string{"server", "client", coap.ExtendedKeyUsage_IDENTITY_CERTIFICATE.String()}
+	csr, err := generateCertificate.GenerateCSR(csrCfg, priv)
+	require.NoError(t, err)
+
+	type fields struct {
+		caCert         []*x509.Certificate
+		caKey          crypto.PrivateKey
+		validNotBefore time.Time
+		validNotAfter  time.Time
+		crlPoints      []string
+	}
+	type args struct {
+		csr []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*x509.Certificate
+		wantErr bool
+	}{
+		{
+			name: "invalid",
+			fields: fields{
+				caCert:         caCert,
+				caKey:          caKey,
+				validNotBefore: time.Now(),
+				validNotAfter:  time.Now().Add(time.Hour * 86400),
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			fields: fields{
+				caCert:         caCert,
+				caKey:          caKey,
+				validNotBefore: time.Now(),
+				validNotAfter:  time.Now().Add(time.Hour * 86400),
+			},
+			args: args{
+				csr: csr,
+			},
+			wantErr: false,
+			want: []*x509.Certificate{
+				{
+					Subject: pkix.Name{
+						CommonName: "uuid:00000000-0000-0000-0000-000000000001",
+					},
+					ExtKeyUsage: []x509.ExtKeyUsage{
+						x509.ExtKeyUsageServerAuth,
+						x509.ExtKeyUsageClientAuth,
+					},
+					UnknownExtKeyUsage: []asn1.ObjectIdentifier{coap.ExtendedKeyUsage_IDENTITY_CERTIFICATE},
+				},
+				{
+					Subject: pkix.Name{
+						CommonName: "intermediateCA",
+					},
+				},
+			},
+		},
+		{
+			name: "valid with CRL points",
+			fields: fields{
+				caCert:         caCert,
+				caKey:          caKey,
+				validNotBefore: time.Now().Add(-time.Second),
+				validNotAfter:  time.Now().Add(time.Hour),
+				crlPoints:      []string{"http://example.com/crl"},
+			},
+			args: args{
+				csr: csr,
+			},
+			want: []*x509.Certificate{
+				{
+					Subject: pkix.Name{
+						CommonName: "uuid:00000000-0000-0000-0000-000000000001",
+					},
+					ExtKeyUsage: []x509.ExtKeyUsage{
+						x509.ExtKeyUsageServerAuth,
+						x509.ExtKeyUsageClientAuth,
+					},
+					UnknownExtKeyUsage:    []asn1.ObjectIdentifier{coap.ExtendedKeyUsage_IDENTITY_CERTIFICATE},
+					CRLDistributionPoints: []string{"http://example.com/crl"},
+				},
+				{
+					Subject: pkix.Name{
+						CommonName: "intermediateCA",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := signer.NewBasicCertificateSigner(tt.fields.caCert, tt.fields.caKey, tt.fields.validNotBefore, tt.fields.validNotAfter, tt.fields.crlPoints)
+			require.NoError(t, err)
+			got, err := s.Sign(context.Background(), tt.args.csr)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			for i := 0; i < len(tt.want); i++ {
+				block, rest := pem.Decode(got)
+				require.NotEmpty(t, block.Bytes)
+				cert, err := x509.ParseCertificate(block.Bytes)
+				require.NoError(t, err)
+				require.Equal(t, tt.want[i].Subject.CommonName, cert.Subject.CommonName)
+				require.Equal(t, tt.want[i].ExtKeyUsage, cert.ExtKeyUsage)
+				require.Equal(t, tt.want[i].UnknownExtKeyUsage, cert.UnknownExtKeyUsage)
+				require.Equal(t, tt.want[i].CRLDistributionPoints, cert.CRLDistributionPoints)
+				got = rest
+			}
+		})
+	}
+}

--- a/pkg/security/x509/parse.go
+++ b/pkg/security/x509/parse.go
@@ -106,3 +106,20 @@ func ParseCertificates(cert *tls.Certificate) ([]*x509.Certificate, error) {
 	}
 	return caChain, nil
 }
+
+func ParseAndCheckCertificateRequest(csr []byte) (*x509.CertificateRequest, error) {
+	csrBlock, _ := pem.Decode(csr)
+	if csrBlock == nil {
+		return nil, errors.New("pem not found")
+	}
+
+	certificateRequest, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	err = certificateRequest.CheckSignature()
+	if err != nil {
+		return nil, err
+	}
+	return certificateRequest, nil
+}

--- a/pkg/security/x509/validate.go
+++ b/pkg/security/x509/validate.go
@@ -1,0 +1,18 @@
+package x509
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ValidateCRLDistributionPoints validates a slice of CRL distribution point URLs.
+// It ensures each URL is properly formatted and returns an error if any URL is invalid.
+// Returns nil if all URLs are valid.
+func ValidateCRLDistributionPoints(crlDistributionPoints []string) error {
+	for _, crl := range crlDistributionPoints {
+		if _, err := url.ParseRequestURI(crl); err != nil {
+			return fmt.Errorf("invalid CRL distribution point URL %q: %w", crl, err)
+		}
+	}
+	return nil
+}

--- a/pkg/security/x509/validate_test.go
+++ b/pkg/security/x509/validate_test.go
@@ -1,0 +1,50 @@
+package x509_test
+
+import (
+	"testing"
+
+	"github.com/plgd-dev/device/v2/pkg/security/x509"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCRLDistributionPoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		crlPoints []string
+		wantErr   bool
+	}{
+		{
+			name:      "Valid CRL distribution points",
+			crlPoints: []string{"http://example.com/crl1", "https://example.com/crl2"},
+		},
+		{
+			name:      "Invalid CRL distribution point",
+			crlPoints: []string{"http://valid-crl.com", "invalid-url"},
+			wantErr:   true,
+		},
+		{
+			name:      "Empty CRL distribution point",
+			crlPoints: []string{"http://example.com/crl1", ""},
+			wantErr:   true,
+		},
+		{
+			name:      "Valid - No CRL distribution points",
+			crlPoints: []string{},
+		},
+		{
+			name:      "Valid - Nil CRL distribution points",
+			crlPoints: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := x509.ValidateCRLDistributionPoints(tt.crlPoints)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/test/signer.go
+++ b/test/signer.go
@@ -26,5 +26,5 @@ func NewTestSigner() (core.CertificateSigner, error) {
 
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour * 86400)
-	return NewIdentityCertificateSigner(identityIntermediateCA, identityIntermediateCAKey, notBefore, notAfter), nil
+	return NewIdentityCertificateSigner(identityIntermediateCA, identityIntermediateCAKey, notBefore, notAfter, nil)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -122,8 +122,8 @@ func FindDeviceByName(ctx context.Context, name string) (deviceID string, _ erro
 	return id, nil
 }
 
-func NewIdentityCertificateSigner(caCert []*x509.Certificate, caKey crypto.PrivateKey, validNotBefore time.Time, validNotAfter time.Time) core.CertificateSigner {
-	return signer.NewOCFIdentityCertificate(caCert, caKey, validNotBefore, validNotAfter)
+func NewIdentityCertificateSigner(caCert []*x509.Certificate, caKey crypto.PrivateKey, validNotBefore, validNotAfter time.Time, crlDistributionPoints []string) (core.CertificateSigner, error) {
+	return signer.NewOCFIdentityCertificate(caCert, caKey, validNotBefore, validNotAfter, crlDistributionPoints)
 }
 
 type IPType int


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for Certificate Revocation List (CRL) distribution points in the certificate signing process.
	- Enhanced identity certificate generation to include CRL distribution points.
	- Added a method for validating and processing CRL distribution points in the configuration.
	- Updated the `BasicCertificateSigner` to include CRL distribution points during certificate signing.
	- Implemented a validation function for CRL distribution points.
	- Added new functions for parsing and checking Certificate Signing Requests (CSRs).

- **Bug Fixes**
	- Adjusted function signatures to ensure compatibility with the new CRL distribution points feature.

- **Documentation**
	- Updated method signatures and descriptions across various components to reflect the addition of CRL distribution points.

- **Tests**
	- Added unit tests for the new `BasicCertificateSigner` functionality to ensure robustness in certificate signing.
	- Implemented tests for CRL distribution points handling in the configuration.
	- Enhanced test coverage for certificate generation functions to validate CRL distribution points.
	- Introduced tests for CSR parsing and validation scenarios.
	- Added tests for validating CRL distribution points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->