### PR TITLE
Feature/no link callback

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -437,7 +437,6 @@ func (c *Client) GetDeviceLinkForHref(
 	discoveryCfg core.DiscoveryConfiguration,
 	callback LinkNotFoundCallback,
 ) (*core.Device, schema.ResourceLink, error) {
-
 	d, links, err := c.GetDevice(ctx, deviceID, WithDiscoveryConfiguration(discoveryCfg))
 	if err != nil {
 		return nil, schema.ResourceLink{}, err

--- a/client/client.go
+++ b/client/client.go
@@ -444,12 +444,11 @@ func (c *Client) GetDeviceLinkForHref(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		if callback.linkNotFoundCallback != nil {
-			link, err = callback.linkNotFoundCallback(links, href)
-			if err != nil {
-				return nil, schema.ResourceLink{}, err
-			}
-		} else {
+		if callback.linkNotFoundCallback == nil {
+			return nil, schema.ResourceLink{}, err
+		}
+		link, err = callback.linkNotFoundCallback(links, href)
+		if err != nil {
 			return nil, schema.ResourceLink{}, err
 		}
 	}

--- a/client/createResource.go
+++ b/client/createResource.go
@@ -52,7 +52,14 @@ func (c *Client) CreateResource(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		return err
+		if cfg.linkNotFoundCallback != nil {
+			link, err = cfg.linkNotFoundCallback(links, href)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	if c.useDeviceIDInQuery {

--- a/client/createResource.go
+++ b/client/createResource.go
@@ -45,26 +45,14 @@ func (c *Client) CreateResource(
 		cfg = o.applyOnCreate(cfg)
 	}
 
-	d, links, err := c.GetDevice(ctx, deviceID, WithDiscoveryConfiguration(cfg.discoveryConfiguration))
+	device, link, err := c.GetDeviceLinkForHref(ctx, deviceID, href, cfg.discoveryConfiguration, LinkNotFoundCallback{linkNotFoundCallback: cfg.linkNotFoundCallback})
 	if err != nil {
 		return err
-	}
-
-	link, err := core.GetResourceLink(links, href)
-	if err != nil {
-		if cfg.linkNotFoundCallback != nil {
-			link, err = cfg.linkNotFoundCallback(links, href)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
 	}
 
 	if c.useDeviceIDInQuery {
 		cfg.opts = append(cfg.opts, coap.WithDeviceID(deviceID))
 	}
 
-	return d.UpdateResourceWithCodec(ctx, link, cfg.codec, request, response, cfg.opts...)
+	return device.UpdateResourceWithCodec(ctx, link, cfg.codec, request, response, cfg.opts...)
 }

--- a/client/createResource_test.go
+++ b/client/createResource_test.go
@@ -71,7 +71,10 @@ func TestClientCreateResource(t *testing.T) {
 				opts: []client.CreateOption{
 					client.WithDiscoveryConfiguration(core.DefaultDiscoveryConfiguration()),
 					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
-						resourceLink, _ := links.GetResourceLink(test.TestResourceSwitchesHref)
+						_, linkFound := links.GetResourceLink(href)
+						require.False(t, linkFound)
+						resourceLink, linkFound := links.GetResourceLink(test.TestResourceSwitchesHref)
+						require.True(t, linkFound)
 						return resourceLink, nil
 					}),
 				},

--- a/client/createResource_test.go
+++ b/client/createResource_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/plgd-dev/device/v2/client"
 	"github.com/plgd-dev/device/v2/client/core"
+	"github.com/plgd-dev/device/v2/schema"
 	"github.com/plgd-dev/device/v2/schema/device"
 	"github.com/plgd-dev/device/v2/schema/interfaces"
 	"github.com/plgd-dev/device/v2/test"
@@ -54,6 +55,29 @@ func TestClientCreateResource(t *testing.T) {
 			},
 			want: test.MakeSwitchResourceData(map[string]interface{}{
 				"href": test.TestResourceSwitchesInstanceHref("1"),
+				"rep": map[interface{}]interface{}{
+					"if":    []interface{}{interfaces.OC_IF_A, interfaces.OC_IF_BASELINE},
+					"rt":    []interface{}{types.BINARY_SWITCH},
+					"value": false,
+				},
+			}),
+		},
+		{
+			name: "test link not found callback",
+			args: args{
+				deviceID: deviceID,
+				href:     "/link/not/found",
+				body:     test.MakeSwitchResourceDefaultData(),
+				opts: []client.CreateOption{
+					client.WithDiscoveryConfiguration(core.DefaultDiscoveryConfiguration()),
+					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+						resourceLink, _ := links.GetResourceLink(test.TestResourceSwitchesHref)
+						return resourceLink, nil
+					}),
+				},
+			},
+			want: test.MakeSwitchResourceData(map[string]interface{}{
+				"href": test.TestResourceSwitchesInstanceHref("2"),
 				"rep": map[interface{}]interface{}{
 					"if":    []interface{}{interfaces.OC_IF_A, interfaces.OC_IF_BASELINE},
 					"rt":    []interface{}{types.BINARY_SWITCH},

--- a/client/deleteResource.go
+++ b/client/deleteResource.go
@@ -48,7 +48,14 @@ func (c *Client) DeleteResource(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		return err
+		if cfg.linkNotFoundCallback != nil {
+			link, err = cfg.linkNotFoundCallback(links, href)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	if c.useDeviceIDInQuery {

--- a/client/deleteResource.go
+++ b/client/deleteResource.go
@@ -41,26 +41,14 @@ func (c *Client) DeleteResource(
 		cfg = o.applyOnDelete(cfg)
 	}
 
-	d, links, err := c.GetDevice(ctx, deviceID, WithDiscoveryConfiguration(cfg.discoveryConfiguration))
+	device, link, err := c.GetDeviceLinkForHref(ctx, deviceID, href, cfg.discoveryConfiguration, LinkNotFoundCallback{linkNotFoundCallback: cfg.linkNotFoundCallback})
 	if err != nil {
 		return err
-	}
-
-	link, err := core.GetResourceLink(links, href)
-	if err != nil {
-		if cfg.linkNotFoundCallback != nil {
-			link, err = cfg.linkNotFoundCallback(links, href)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
 	}
 
 	if c.useDeviceIDInQuery {
 		cfg.opts = append(cfg.opts, coap.WithDeviceID(deviceID))
 	}
 
-	return d.DeleteResourceWithCodec(ctx, link, cfg.codec, response, cfg.opts...)
+	return device.DeleteResourceWithCodec(ctx, link, cfg.codec, response, cfg.opts...)
 }

--- a/client/deleteResource_test.go
+++ b/client/deleteResource_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/plgd-dev/device/v2/client"
 	"github.com/plgd-dev/device/v2/client/core"
 	"github.com/plgd-dev/device/v2/schema"
+	"github.com/plgd-dev/device/v2/schema/configuration"
 	"github.com/plgd-dev/device/v2/schema/device"
 	"github.com/plgd-dev/device/v2/schema/interfaces"
 	"github.com/plgd-dev/device/v2/schema/resources"
@@ -56,6 +57,24 @@ func TestClientDeleteResource(t *testing.T) {
 		switchID_1 = "1"
 		switchID_2 = "2"
 	)
+
+	c, err := testClient.NewTestSecureClient()
+	require.NoError(t, err)
+	defer func() {
+		errC := c.Close(context.Background())
+		require.NoError(t, errC)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), test.TestTimeout)
+	defer cancel()
+	deviceID, err = c.OwnDevice(ctx, deviceID, client.WithOTMs([]client.OTMType{client.OTMType_JustWorks}))
+	require.NoError(t, err)
+	defer disown(t, c, deviceID)
+
+	createSwitches(ctx, t, c, deviceID, 2)
+	var nonDiscoverableResource map[string]interface{}
+	err = c.CreateResource(ctx, deviceID, test.TestResourceSwitchesHref, test.MakeNonDiscoverableSwitchData(), &nonDiscoverableResource)
+	require.NoError(t, err)
+
 	type args struct {
 		deviceID string
 		href     string
@@ -75,15 +94,18 @@ func TestClientDeleteResource(t *testing.T) {
 			},
 		},
 		{
-			name: "link not found",
+			name: "delete non-discoverable resource",
 			args: args{
 				deviceID: deviceID,
-				href:     "/link/not/found",
+				href:     nonDiscoverableResource["href"].(string),
 				opts: []client.DeleteOption{
 					client.WithDiscoveryConfiguration(core.DefaultDiscoveryConfiguration()),
-					// test the LinkNotFoundCallback by providing wrong href and returning a valid link for expected resource
+					// create the link for non-discoverable resource by utilizing the linkNotFoundCallback
+					// as the only thing that we need in the link is the href and endpoints we will reuse
+					// some known discoverable resource
 					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
-						resourceLink, _ := links.GetResourceLink(test.TestResourceSwitchesInstanceHref(switchID_2))
+						resourceLink, _ := links.GetResourceLink(configuration.ResourceURI)
+						resourceLink.Href = href
 						return resourceLink, nil
 					}),
 				},
@@ -106,20 +128,6 @@ func TestClientDeleteResource(t *testing.T) {
 			wantErr: true,
 		},
 	}
-
-	c, err := testClient.NewTestSecureClient()
-	require.NoError(t, err)
-	defer func() {
-		errC := c.Close(context.Background())
-		require.NoError(t, errC)
-	}()
-	ctx, cancel := context.WithTimeout(context.Background(), test.TestTimeout)
-	defer cancel()
-	deviceID, err = c.OwnDevice(ctx, deviceID, client.WithOTMs([]client.OTMType{client.OTMType_JustWorks}))
-	require.NoError(t, err)
-	defer disown(t, c, deviceID)
-
-	createSwitches(ctx, t, c, deviceID, 2)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/getResource.go
+++ b/client/getResource.go
@@ -40,26 +40,15 @@ func (c *Client) GetResource(
 	for _, o := range opts {
 		cfg = o.applyOnGet(cfg)
 	}
-	d, links, err := c.GetDevice(ctx, deviceID, WithDiscoveryConfiguration(cfg.discoveryConfiguration))
+
+	device, link, err := c.GetDeviceLinkForHref(ctx, deviceID, href, cfg.discoveryConfiguration, LinkNotFoundCallback{linkNotFoundCallback: cfg.linkNotFoundCallback})
 	if err != nil {
 		return err
-	}
-
-	link, err := core.GetResourceLink(links, href)
-	if err != nil {
-		if cfg.linkNotFoundCallback != nil {
-			link, err = cfg.linkNotFoundCallback(links, href)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
 	}
 
 	if c.useDeviceIDInQuery {
 		cfg.opts = append(cfg.opts, coap.WithDeviceID(deviceID))
 	}
 
-	return d.GetResourceWithCodec(ctx, link, cfg.codec, response, cfg.opts...)
+	return device.GetResourceWithCodec(ctx, link, cfg.codec, response, cfg.opts...)
 }

--- a/client/getResource.go
+++ b/client/getResource.go
@@ -47,7 +47,14 @@ func (c *Client) GetResource(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		return err
+		if cfg.linkNotFoundCallback != nil {
+			link, err = cfg.linkNotFoundCallback(links, href)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	if c.useDeviceIDInQuery {

--- a/client/getResource_test.go
+++ b/client/getResource_test.go
@@ -18,6 +18,7 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -115,10 +116,10 @@ func TestClientGetResource(t *testing.T) {
 					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 						resourceLink, ok := links.GetResourceLink(configuration.ResourceURI)
 						if !ok {
-							return schema.ResourceLink{}, fmt.Errorf("resource link not found: %s", configuration.ResourceURI)
+							return schema.ResourceLink{}, errors.New("resource link not found: " + configuration.ResourceURI)
 						}
 						if len(resourceLink.Endpoints) == 0 {
-							return schema.ResourceLink{}, fmt.Errorf("resource link has no endpoints")
+							return schema.ResourceLink{}, errors.New("resource link has no endpoints")
 						}
 						resourceLink.Href = href
 						return resourceLink, nil

--- a/client/getResource_test.go
+++ b/client/getResource_test.go
@@ -113,7 +113,10 @@ func TestClientGetResource(t *testing.T) {
 					// as the only thing that we need in the link is the href and endpoints we will reuse
 					// some known discoverable resource
 					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
-						resourceLink, _ := links.GetResourceLink(configuration.ResourceURI)
+						resourceLink, ok := links.GetResourceLink(configuration.ResourceURI)
+						if !ok {
+							return schema.ResourceLink{}, fmt.Errorf("failed to get resource link: %w", err)
+						}
 						resourceLink.Href = href
 						return resourceLink, nil
 					}),

--- a/client/getResource_test.go
+++ b/client/getResource_test.go
@@ -87,6 +87,27 @@ func TestClientGetResource(t *testing.T) {
 			},
 		},
 		{
+			name: "link not found callback",
+			args: args{
+				deviceID: deviceID,
+				href:     "/link/not/found",
+				opts: []client.GetOption{
+					client.WithDiscoveryConfiguration(core.DefaultDiscoveryConfiguration()),
+					// test the LinkNotFoundCallback by providing wrong href and returning a valid link for expected resource
+					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+						resourceLink, _ := links.GetResourceLink(configuration.ResourceURI)
+						return resourceLink, nil
+					}),
+				},
+			},
+			want: coap.DetailedResponse[interface{}]{
+				Code: codes.Content,
+				Body: map[interface{}]interface{}{
+					"n": test.DevsimName,
+				},
+			},
+		},
+		{
 			name: "invalid href",
 			args: args{
 				deviceID: deviceID,

--- a/client/getResource_test.go
+++ b/client/getResource_test.go
@@ -115,7 +115,10 @@ func TestClientGetResource(t *testing.T) {
 					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 						resourceLink, ok := links.GetResourceLink(configuration.ResourceURI)
 						if !ok {
-							return schema.ResourceLink{}, fmt.Errorf("failed to get resource link: %w", err)
+							return schema.ResourceLink{}, fmt.Errorf("resource link not found: %s", configuration.ResourceURI)
+						}
+						if len(resourceLink.Endpoints) == 0 {
+							return schema.ResourceLink{}, fmt.Errorf("resource link has no endpoints")
 						}
 						resourceLink.Href = href
 						return resourceLink, nil

--- a/client/observeResource.go
+++ b/client/observeResource.go
@@ -233,7 +233,14 @@ func (c *Client) ObserveResource(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		return "", err
+		if cfg.linkNotFoundCallback != nil {
+			link, err = cfg.linkNotFoundCallback(links, href)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
 	}
 
 	if c.useDeviceIDInQuery {

--- a/client/observeResource_test.go
+++ b/client/observeResource_test.go
@@ -179,16 +179,8 @@ func TestObservingNonDiscoverableResource(t *testing.T) {
 		}
 
 		// create a non-discoverable switch resource
-		overrideParameters := map[string]interface{}{
-			"if": []interface{}{interfaces.OC_IF_A, interfaces.OC_IF_BASELINE},
-			"p": map[interface{}]interface{}{
-				"bm": uint64(schema.Observable), // let's make the resource only observable
-			},
-		}
-		switchResourceData := test.MakeSwitchResourceData(overrideParameters)
-
 		var got map[string]interface{}
-		err := c.CreateResource(ctx, deviceID, test.TestResourceSwitchesHref, switchResourceData, &got)
+		err := c.CreateResource(ctx, deviceID, test.TestResourceSwitchesHref, test.MakeNonDiscoverableSwitchData(), &got)
 		require.NoError(t, err)
 		// remove the instance parameter as the number is assigned by the device and we can't predict its value
 		delete(got, "ins")

--- a/client/options.go
+++ b/client/options.go
@@ -299,6 +299,11 @@ type LinkNotFoundCallback struct {
 	linkNotFoundCallback func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
+func (r LinkNotFoundCallback) applyOnCreate(opts createOptions) createOptions {
+	opts.linkNotFoundCallback = r.linkNotFoundCallback
+	return opts
+}
+
 func (r LinkNotFoundCallback) applyOnGet(opts getOptions) getOptions {
 	opts.linkNotFoundCallback = r.linkNotFoundCallback
 	return opts
@@ -353,6 +358,7 @@ type createOptions struct {
 	opts                   []coap.OptionFunc
 	codec                  coap.Codec
 	discoveryConfiguration core.DiscoveryConfiguration
+	linkNotFoundCallback   func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
 type deleteOptions struct {

--- a/client/options.go
+++ b/client/options.go
@@ -295,6 +295,41 @@ func WithDiscoveryConfiguration(cfg core.DiscoveryConfiguration) DiscoveryConfig
 	}
 }
 
+type LinkNotFoundCallback struct {
+	linkNotFoundCallback func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
+}
+
+func (r LinkNotFoundCallback) applyOnGet(opts getOptions) getOptions {
+	opts.linkNotFoundCallback = r.linkNotFoundCallback
+	return opts
+}
+
+func (r LinkNotFoundCallback) applyOnUpdate(opts updateOptions) updateOptions {
+	opts.linkNotFoundCallback = r.linkNotFoundCallback
+	return opts
+}
+
+func (r LinkNotFoundCallback) applyOnObserve(opts observeOptions) observeOptions {
+	opts.linkNotFoundCallback = r.linkNotFoundCallback
+	return opts
+}
+
+func (r LinkNotFoundCallback) applyOnDelete(opts deleteOptions) deleteOptions {
+	opts.linkNotFoundCallback = r.linkNotFoundCallback
+	return opts
+}
+
+// WithLinkNotFoundCallback is used if the target of the link is not known e.g. the resource is not present on the device
+// or the resource is non-discoverable.
+// linkNotFoundCallback is a function which is called with links and href of the resource.
+// It returns a link and an error. If the error is not nil, then the link is skipped.
+// Otherwise the link is replaced with the returned link.
+func WithLinkNotFoundCallback(linkNotFoundCallback func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)) LinkNotFoundCallback {
+	return LinkNotFoundCallback{
+		linkNotFoundCallback: linkNotFoundCallback,
+	}
+}
+
 // GetOption option definition.
 type GetOption = interface {
 	applyOnGet(opts getOptions) getOptions
@@ -304,12 +339,14 @@ type getOptions struct {
 	opts                   []coap.OptionFunc
 	codec                  coap.Codec
 	discoveryConfiguration core.DiscoveryConfiguration
+	linkNotFoundCallback   func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
 type updateOptions struct {
 	opts                   []coap.OptionFunc
 	codec                  coap.Codec
 	discoveryConfiguration core.DiscoveryConfiguration
+	linkNotFoundCallback   func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
 type createOptions struct {
@@ -322,6 +359,7 @@ type deleteOptions struct {
 	opts                   []coap.OptionFunc
 	codec                  coap.Codec
 	discoveryConfiguration core.DiscoveryConfiguration
+	linkNotFoundCallback   func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
 // CreateOption option definition.
@@ -459,6 +497,7 @@ type observeOptions struct {
 	opts                   []coap.OptionFunc
 	resourceInterface      string
 	discoveryConfiguration core.DiscoveryConfiguration
+	linkNotFoundCallback   func(links schema.ResourceLinks, href string) (schema.ResourceLink, error)
 }
 
 // ObserveOption option definition.

--- a/client/options_internal_test.go
+++ b/client/options_internal_test.go
@@ -82,6 +82,20 @@ func checkLinkNotFoundCallback(t *testing.T, callback LinkNotFoundCallback, notF
 	require.Equal(t, notFoundTestLink, foundLink.Href)
 }
 
+func checkMessageOptions(t *testing.T, opts []func(message.Options) message.Options) {
+	mopts := message.Options{}
+	for _, mopt := range opts {
+		mopts = mopt(mopts)
+	}
+
+	queries, err := mopts.Queries()
+	require.NoError(t, err)
+	// WithInterface
+	require.Contains(t, queries, ifquery())
+	// WithQuery
+	require.Contains(t, queries, testQuery)
+}
+
 func TestApplyOnGet(t *testing.T) {
 	discoveryCfg := core.DiscoveryConfiguration{
 		MulticastHopLimit: 42,
@@ -161,18 +175,8 @@ func TestApplyOnObserve(t *testing.T) {
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
 	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/observe/notfound")
-
-	mopts := message.Options{}
-	for _, mopt := range o.opts {
-		mopts = mopt(mopts)
-	}
-
-	queries, err := mopts.Queries()
-	require.NoError(t, err)
-	// WithInterface
-	require.Contains(t, queries, ifquery())
-	// WithQuery
-	require.Contains(t, queries, testQuery)
+	// check message options
+	checkMessageOptions(t, o.opts)
 }
 
 func TestApplyOnUpdate(t *testing.T) {
@@ -202,18 +206,8 @@ func TestApplyOnUpdate(t *testing.T) {
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
 	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/update/notfound")
-
-	mopts := message.Options{}
-	for _, mopt := range o.opts {
-		mopts = mopt(mopts)
-	}
-
-	queries, err := mopts.Queries()
-	require.NoError(t, err)
-	// WithInterface
-	require.Contains(t, queries, ifquery())
-	// WithQuery
-	require.Contains(t, queries, testQuery)
+	// check message options
+	checkMessageOptions(t, o.opts)
 }
 
 func TestApplyOnCreate(t *testing.T) {
@@ -281,18 +275,8 @@ func TestApplyOnDelete(t *testing.T) {
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
 	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/delete/notfound")
-
-	mopts := message.Options{}
-	for _, mopt := range o.opts {
-		mopts = mopt(mopts)
-	}
-
-	queries, err := mopts.Queries()
-	require.NoError(t, err)
-	// WithInterface
-	require.Contains(t, queries, ifquery())
-	// WithQuery
-	require.Contains(t, queries, testQuery)
+	// check message options
+	checkMessageOptions(t, o.opts)
 }
 
 func TestApplyOnOwn(t *testing.T) {

--- a/client/options_internal_test.go
+++ b/client/options_internal_test.go
@@ -81,7 +81,7 @@ func TestApplyOnGet(t *testing.T) {
 	}
 	etag := "123"
 	codec := ocf.VNDOCFCBORCodec{}
-	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+	linkNotFoundCallback := func(_ schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 		return schema.ResourceLink{Href: href}, nil
 	}
 	opts := []GetOption{
@@ -135,7 +135,7 @@ func TestApplyOnObserve(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
-	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+	linkNotFoundCallback := func(_ schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 		return schema.ResourceLink{Href: href}, nil
 	}
 
@@ -181,7 +181,7 @@ func TestApplyOnUpdate(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
-	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+	linkNotFoundCallback := func(_ schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 		return schema.ResourceLink{Href: href}, nil
 	}
 	opts := []UpdateOption{
@@ -226,7 +226,7 @@ func TestApplyOnCreate(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
-	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+	linkNotFoundCallback := func(_ schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 		return schema.ResourceLink{Href: href}, nil
 	}
 	opts := []CreateOption{
@@ -268,7 +268,7 @@ func TestApplyOnDelete(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
-	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+	linkNotFoundCallback := func(_ schema.ResourceLinks, href string) (schema.ResourceLink, error) {
 		return schema.ResourceLink{Href: href}, nil
 	}
 	opts := []DeleteOption{

--- a/client/options_internal_test.go
+++ b/client/options_internal_test.go
@@ -75,6 +75,13 @@ func TestApplyOnCommonCommand(t *testing.T) {
 	require.Contains(t, queries, "di="+deviceID)
 }
 
+func checkLinkNotFoundCallback(t *testing.T, callback LinkNotFoundCallback, notFoundTestLink string) {
+	require.NotNil(t, callback.linkNotFoundCallback)
+	foundLink, err := callback.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
+}
+
 func TestApplyOnGet(t *testing.T) {
 	discoveryCfg := core.DiscoveryConfiguration{
 		MulticastHopLimit: 42,
@@ -104,11 +111,7 @@ func TestApplyOnGet(t *testing.T) {
 	// WithCodec
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
-	require.NotNil(t, o.linkNotFoundCallback)
-	notFoundTestLink := "/get/notfound"
-	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
-	require.NoError(t, err)
-	require.Equal(t, notFoundTestLink, foundLink.Href)
+	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/get/notfound")
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -157,11 +160,7 @@ func TestApplyOnObserve(t *testing.T) {
 	// WithCodec
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
-	require.NotNil(t, o.linkNotFoundCallback)
-	notFoundTestLink := "/observe/notfound"
-	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
-	require.NoError(t, err)
-	require.Equal(t, notFoundTestLink, foundLink.Href)
+	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/observe/notfound")
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -202,11 +201,7 @@ func TestApplyOnUpdate(t *testing.T) {
 	// WithCodec
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
-	require.NotNil(t, o.linkNotFoundCallback)
-	notFoundTestLink := "/update/notfound"
-	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
-	require.NoError(t, err)
-	require.Equal(t, notFoundTestLink, foundLink.Href)
+	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/update/notfound")
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -246,11 +241,7 @@ func TestApplyOnCreate(t *testing.T) {
 	// WithCodec
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
-	require.NotNil(t, o.linkNotFoundCallback)
-	notFoundTestLink := "/update/notfound"
-	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
-	require.NoError(t, err)
-	require.Equal(t, notFoundTestLink, foundLink.Href)
+	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/create/notfound")
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -289,11 +280,7 @@ func TestApplyOnDelete(t *testing.T) {
 	// WithCodec
 	require.Equal(t, codec, o.codec)
 	// WithLinkNotFoundCallback
-	require.NotNil(t, o.linkNotFoundCallback)
-	notFoundTestLink := "/delete/notfound"
-	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
-	require.NoError(t, err)
-	require.Equal(t, notFoundTestLink, foundLink.Href)
+	checkLinkNotFoundCallback(t, LinkNotFoundCallback{linkNotFoundCallback: o.linkNotFoundCallback}, "/delete/notfound")
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {

--- a/client/options_internal_test.go
+++ b/client/options_internal_test.go
@@ -81,6 +81,9 @@ func TestApplyOnGet(t *testing.T) {
 	}
 	etag := "123"
 	codec := ocf.VNDOCFCBORCodec{}
+	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+		return schema.ResourceLink{Href: href}, nil
+	}
 	opts := []GetOption{
 		WithDiscoveryConfiguration(discoveryCfg),
 		WithETag([]byte(etag)),
@@ -88,6 +91,7 @@ func TestApplyOnGet(t *testing.T) {
 		WithQuery(testQuery),
 		WithResourceTypes(testRt),
 		WithCodec(codec),
+		WithLinkNotFoundCallback(linkNotFoundCallback),
 	}
 
 	var o getOptions
@@ -99,6 +103,12 @@ func TestApplyOnGet(t *testing.T) {
 	require.Equal(t, discoveryCfg, o.discoveryConfiguration)
 	// WithCodec
 	require.Equal(t, codec, o.codec)
+	// WithLinkNotFoundCallback
+	require.NotNil(t, o.linkNotFoundCallback)
+	notFoundTestLink := "/get/notfound"
+	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -125,11 +135,16 @@ func TestApplyOnObserve(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
+	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+		return schema.ResourceLink{Href: href}, nil
+	}
+
 	opts := []ObserveOption{
 		WithDiscoveryConfiguration(discoveryCfg),
 		WithInterface(testIface),
 		WithQuery(testQuery),
 		WithCodec(codec),
+		WithLinkNotFoundCallback(linkNotFoundCallback),
 	}
 
 	var o observeOptions
@@ -141,6 +156,12 @@ func TestApplyOnObserve(t *testing.T) {
 	require.Equal(t, discoveryCfg, o.discoveryConfiguration)
 	// WithCodec
 	require.Equal(t, codec, o.codec)
+	// WithLinkNotFoundCallback
+	require.NotNil(t, o.linkNotFoundCallback)
+	notFoundTestLink := "/observe/notfound"
+	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -160,11 +181,15 @@ func TestApplyOnUpdate(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
+	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+		return schema.ResourceLink{Href: href}, nil
+	}
 	opts := []UpdateOption{
 		WithDiscoveryConfiguration(discoveryCfg),
 		WithInterface(testIface),
 		WithQuery(testQuery),
 		WithCodec(codec),
+		WithLinkNotFoundCallback(linkNotFoundCallback),
 	}
 
 	var o updateOptions
@@ -176,6 +201,12 @@ func TestApplyOnUpdate(t *testing.T) {
 	require.Equal(t, discoveryCfg, o.discoveryConfiguration)
 	// WithCodec
 	require.Equal(t, codec, o.codec)
+	// WithLinkNotFoundCallback
+	require.NotNil(t, o.linkNotFoundCallback)
+	notFoundTestLink := "/update/notfound"
+	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {
@@ -227,11 +258,15 @@ func TestApplyOnDelete(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
+	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+		return schema.ResourceLink{Href: href}, nil
+	}
 	opts := []DeleteOption{
 		WithDiscoveryConfiguration(discoveryCfg),
 		WithInterface(testIface),
 		WithQuery(testQuery),
 		WithCodec(codec),
+		WithLinkNotFoundCallback(linkNotFoundCallback),
 	}
 
 	var o deleteOptions
@@ -243,6 +278,12 @@ func TestApplyOnDelete(t *testing.T) {
 	require.Equal(t, discoveryCfg, o.discoveryConfiguration)
 	// WithCodec
 	require.Equal(t, codec, o.codec)
+	// WithLinkNotFoundCallback
+	require.NotNil(t, o.linkNotFoundCallback)
+	notFoundTestLink := "/delete/notfound"
+	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {

--- a/client/options_internal_test.go
+++ b/client/options_internal_test.go
@@ -226,10 +226,14 @@ func TestApplyOnCreate(t *testing.T) {
 		MulticastHopLimit: 42,
 	}
 	codec := ocf.VNDOCFCBORCodec{}
+	linkNotFoundCallback := func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+		return schema.ResourceLink{Href: href}, nil
+	}
 	opts := []CreateOption{
 		WithDiscoveryConfiguration(discoveryCfg),
 		WithQuery(testQuery),
 		WithCodec(codec),
+		WithLinkNotFoundCallback(linkNotFoundCallback),
 	}
 
 	var o createOptions
@@ -241,6 +245,12 @@ func TestApplyOnCreate(t *testing.T) {
 	require.Equal(t, discoveryCfg, o.discoveryConfiguration)
 	// WithCodec
 	require.Equal(t, codec, o.codec)
+	// WithLinkNotFoundCallback
+	require.NotNil(t, o.linkNotFoundCallback)
+	notFoundTestLink := "/update/notfound"
+	foundLink, err := o.linkNotFoundCallback(nil, notFoundTestLink)
+	require.NoError(t, err)
+	require.Equal(t, notFoundTestLink, foundLink.Href)
 
 	mopts := message.Options{}
 	for _, mopt := range o.opts {

--- a/client/updateResource.go
+++ b/client/updateResource.go
@@ -50,8 +50,16 @@ func (c *Client) UpdateResource(
 
 	link, err := core.GetResourceLink(links, href)
 	if err != nil {
-		return err
+		if cfg.linkNotFoundCallback != nil {
+			link, err = cfg.linkNotFoundCallback(links, href)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
+
 	if c.useDeviceIDInQuery {
 		cfg.opts = append(cfg.opts, coap.WithDeviceID(deviceID))
 	}

--- a/client/updateResource.go
+++ b/client/updateResource.go
@@ -43,26 +43,14 @@ func (c *Client) UpdateResource(
 		cfg = o.applyOnUpdate(cfg)
 	}
 
-	d, links, err := c.GetDevice(ctx, deviceID, WithDiscoveryConfiguration(cfg.discoveryConfiguration))
+	device, link, err := c.GetDeviceLinkForHref(ctx, deviceID, href, cfg.discoveryConfiguration, LinkNotFoundCallback{linkNotFoundCallback: cfg.linkNotFoundCallback})
 	if err != nil {
 		return err
-	}
-
-	link, err := core.GetResourceLink(links, href)
-	if err != nil {
-		if cfg.linkNotFoundCallback != nil {
-			link, err = cfg.linkNotFoundCallback(links, href)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
 	}
 
 	if c.useDeviceIDInQuery {
 		cfg.opts = append(cfg.opts, coap.WithDeviceID(deviceID))
 	}
 
-	return d.UpdateResourceWithCodec(ctx, link, cfg.codec, request, response, cfg.opts...)
+	return device.UpdateResourceWithCodec(ctx, link, cfg.codec, request, response, cfg.opts...)
 }

--- a/client/updateResource_test.go
+++ b/client/updateResource_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/plgd-dev/device/v2/client"
 	"github.com/plgd-dev/device/v2/client/core"
 	"github.com/plgd-dev/device/v2/pkg/net/coap"
+	"github.com/plgd-dev/device/v2/schema"
 	"github.com/plgd-dev/device/v2/schema/configuration"
 	"github.com/plgd-dev/device/v2/schema/device"
 	"github.com/plgd-dev/device/v2/schema/interfaces"
@@ -77,6 +78,30 @@ func TestClientUpdateResource(t *testing.T) {
 				Code: codes.Changed,
 				Body: map[interface{}]interface{}{
 					"n": t.Name() + "-valid with interface",
+				},
+			},
+		},
+		{
+			name: "valid with link not found",
+			args: args{
+				deviceID: deviceID,
+				href:     "/link/not/found",
+				data: map[string]interface{}{
+					"n": t.Name() + "-valid with link not found",
+				},
+				opts: []client.UpdateOption{
+					client.WithDiscoveryConfiguration(core.DefaultDiscoveryConfiguration()),
+					// test the LinkNotFoundCallback by providing wrong href and returning a valid link for expected resource
+					client.WithLinkNotFoundCallback(func(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {
+						resourceLink, _ := links.GetResourceLink(configuration.ResourceURI)
+						return resourceLink, nil
+					}),
+				},
+			},
+			want: coap.DetailedResponse[interface{}]{
+				Code: codes.Changed,
+				Body: map[interface{}]interface{}{
+					"n": t.Name() + "-valid with link not found",
 				},
 			},
 		},

--- a/test/test.go
+++ b/test/test.go
@@ -267,6 +267,17 @@ func MakeSwitchResourceData(overrides map[string]interface{}) map[string]interfa
 	return data
 }
 
+func MakeNonDiscoverableSwitchData() map[string]interface{} {
+	// create a non-discoverable switch resource
+	overrideParameters := map[string]interface{}{
+		"if": []interface{}{interfaces.OC_IF_A, interfaces.OC_IF_BASELINE},
+		"p": map[interface{}]interface{}{
+			"bm": uint64(schema.Observable), // let's make the resource only observable
+		},
+	}
+	return MakeSwitchResourceData(overrideParameters)
+}
+
 func DefaultDevsimResourceLinks() schema.ResourceLinks {
 	res := TestDevsimResources
 	res = append(res, TestDevsimSecResources...)


### PR DESCRIPTION
This PR adds possibility to create, get, update, delete and observer non-discoverable resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error handling for resource link retrieval across multiple methods, allowing for customizable behavior when links are not found.
	- Introduced a new callback mechanism (`linkNotFoundCallback`) for handling missing resource links during create, update, delete, and observe operations.
	- Added a method to retrieve device links directly based on device ID and href.

- **Bug Fixes**
	- Improved robustness of existing methods to manage non-discoverable resources effectively.

- **Tests**
	- Added new test cases for handling non-discoverable resources across various functionalities, ensuring comprehensive coverage of error handling scenarios.
	- Introduced a utility function to create non-discoverable switch resources for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->